### PR TITLE
Fix /cv constant reload from Notion iframe under SwipeProvider

### DIFF
--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -1,5 +1,45 @@
+import type { Metadata } from "next";
+import BackButton from "@/components/BackButton";
+
+export const metadata: Metadata = {
+  title: "CV · Tino Purmann",
+  description: "Curriculum vitae of Tino Purmann",
+};
+
+const NOTION_EMBED_URL =
+  "https://tinopurmann.notion.site/ebd/1c726a26061480699969e4d1931eff5e";
+
+const NOTION_PUBLIC_URL =
+  "https://tinopurmann.notion.site/Hey-I-m-Tino-Purmann-1c726a26061480699969e4d1931eff5e";
+
+/**
+ * Notion embeds remount when nested under the global SwipeProvider (CSS
+ * transform + overflow:hidden). SwipeProvider now skips /cv, and this page
+ * uses a fixed dvh frame instead of h-[100vh] to avoid mobile chrome thrash.
+ */
 export default function CV() {
-    return (
-        <iframe className="w-full h-[100vh]" src="https://tinopurmann.notion.site/ebd/1c726a26061480699969e4d1931eff5e" allowFullScreen/>
-    )
+  return (
+    <main className="fixed inset-0 bg-white">
+      <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-start justify-between p-3">
+        <div className="pointer-events-auto rounded-md bg-white/95 text-neutral-800 shadow-sm ring-1 ring-black/5">
+          <BackButton />
+        </div>
+        <a
+          href={NOTION_PUBLIC_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="pointer-events-auto rounded-md bg-white/95 px-3 py-1.5 text-sm text-neutral-700 shadow-sm ring-1 ring-black/5 hover:bg-white"
+        >
+          Open directly
+        </a>
+      </div>
+      <iframe
+        title="Tino Purmann CV"
+        src={NOTION_EMBED_URL}
+        className="absolute inset-0 h-[100dvh] w-full border-0"
+        allowFullScreen
+        referrerPolicy="strict-origin-when-cross-origin"
+      />
+    </main>
+  );
 }

--- a/src/components/SwipeProvider/SwipeProvider.tsx
+++ b/src/components/SwipeProvider/SwipeProvider.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { ReactNode, useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import styles from './SwipeProvider.module.css';
 
 interface SwipeProviderProps {
@@ -11,6 +11,11 @@ interface SwipeProviderProps {
 
 export default function SwipeProvider({ children }: SwipeProviderProps) {
     const router = useRouter();
+    const pathname = usePathname();
+
+    // Notion's embed SPA remounts when wrapped in a transformed / overflow-hidden
+    // container — skip the swipe chrome on /cv so the iframe stays stable.
+    const disableSwipe = pathname === '/cv';
 
     // Refs to track touch positions
     const touchStartX = useRef<number | null>(null);
@@ -24,6 +29,12 @@ export default function SwipeProvider({ children }: SwipeProviderProps) {
     const [isAnimating, setIsAnimating] = useState(false);
 
     useEffect(() => {
+        if (disableSwipe) {
+            setTranslateX(0);
+            setIsAnimating(false);
+            return;
+        }
+
         const handleTouchStart = (e: TouchEvent) => {
             // Check if touch started on an element that should disable swipe
             const targetElement = e.target as HTMLElement;
@@ -102,7 +113,11 @@ export default function SwipeProvider({ children }: SwipeProviderProps) {
             document.removeEventListener('touchmove', handleTouchMove);
             document.removeEventListener('touchend', handleTouchEnd);
         };
-    }, [router]);
+    }, [router, disableSwipe]);
+
+    if (disableSwipe) {
+        return <>{children}</>;
+    }
 
     return (
         <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`/cv` embeds a Notion page in a full-viewport iframe. That iframe sat inside the global `SwipeProvider`, which wraps every page in a container with:

- `transform: translateX(...)`
- `overflow: hidden`
- `height: 100%`

Notion’s embed SPA is sensitive to that kind of parent — it remounts / reboots and looks like the page is “constantly reloading.” Mobile `100vh` chrome show/hide made it worse.

## Fix

1. **Skip swipe chrome on `/cv`** — `SwipeProvider` detects the path and renders children without the transformed wrapper or touch handlers.
2. **Stabilize the embed** — fixed `inset-0` + `100dvh` iframe instead of `h-[100vh]`.
3. **Escape hatch** — “Open directly” link to the public Notion page if the embed still misbehaves (e.g. strict third-party cookie blocking).
4. **Back control** — floating back button since swipe-back is disabled on this route.

## Notes

I couldn’t reproduce a hard parent-tab reload loop in headless Chrome (the live page settles after Notion’s internal `/ebd/` → `/ebd//` navigation), but the SwipeProvider wrapper is the clear instability in this codebase. If reload persists in Safari after this, switch `/cv` to a server redirect to the Notion URL — iframe embeds of Notion are unreliable when third-party cookies are blocked.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbe07-b3a9-7705-bad4-84b862bfb8bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbe07-b3a9-7705-bad4-84b862bfb8bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

